### PR TITLE
#545 ユーザーページの活動履歴で、「タグ変更」「カテゴリーを変更」を表示しないようにする

### DIFF
--- a/pages/user-activities.php
+++ b/pages/user-activities.php
@@ -17,7 +17,8 @@
     $comments_sel['columns']['format'] = '^posts.format';
     $edit_sel['columns']['content'] = '^posts.content';
     $edit_sel['columns']['format'] = '^posts.format';
-    
+	$edit_sel['source'] .= " AND editposts.updatetype NOT IN ('A', 'T')";
+	
     list($activities, $answerqs, $commentqs, $editqs) = qa_db_select_with_pending(
         $activities_sel,
         $answers_sel,


### PR DESCRIPTION
* アクティビティ取得の条件を追加して
  - タグ変更
  - カテゴリ変更
は取得しないようにする