### PR TITLE
ユーザー詳細のフォローのリストの表示数と、タブの数の表示が一致していない

### DIFF
--- a/cud-utils.php
+++ b/cud-utils.php
@@ -26,15 +26,23 @@ class cud_utils
         return qa_db_read_one_value(qa_db_query_sub($sql, $userid, $days));
     }
 
+    /*
+     * フォロー、ファオロワーの数を取得
+     */
     public static function get_follows_count($userid)
     {
         $sql = "SELECT ";
-        $sql .= "(SELECT COUNT(*) FROM ^userfavorites WHERE entitytype = 'U' AND userid = $) AS following, ";
-        $sql .= "(SELECT COUNT(*) FROM ^userfavorites WHERE entitytype = 'U' AND entityid = $) AS followers ";
+        $sql .= " (SELECT COUNT(*) FROM ^users WHERE userid IN ";
+        $sql .= "   (SELECT entityid FROM ^userfavorites WHERE entitytype = 'U' AND userid = $)) AS following, ";
+        $sql .= " (SELECT COUNT(*) FROM ^users WHERE userid IN ";
+        $sql .= "   (SELECT userid FROM ^userfavorites WHERE entitytype = 'U' AND entityid = $)) AS followers ";
         
         return qa_db_read_one_assoc(qa_db_query_sub($sql, $userid, $userid));
     }
 
+    /*
+     * フォローまたはフォロワー取得のクエリを返す
+     */
     public static function get_follows_query($type)
     {
         $query = "";
@@ -60,6 +68,9 @@ class cud_utils
         return $query;
     }
 
+    /*
+     * ユーザーリスト用のデータの配列を返す
+     */
     public static function get_users_items($users)
     {
         $items = array();

--- a/pages/user-follows.php
+++ b/pages/user-follows.php
@@ -17,7 +17,8 @@
         $handle = qa_get_logged_in_handle();
         qa_redirect(!empty($handle) ? 'user/'.$handle : 'users');
     }
-    $userid = qa_db_user_find_by_handle($handle);
+    $userids = qa_db_user_find_by_handle($handle);
+    $userid = $userids[0];
 
     //    Get list of favorites users
     $selectspec = qa_db_top_users_selectspec($start, qa_opt_if_loaded('page_size_users'));


### PR DESCRIPTION
* フォロー、フォロワーの数取得SQLを変更
  - qa_userfavorites ではなく qa_users でカウントする