### PR TITLE
1455 別Q&Aに分けるための修正

### DIFF
--- a/cud-html-builder.php
+++ b/cud-html-builder.php
@@ -27,15 +27,16 @@ class cud_html_builder
       $template_path = CUD_DIR . '/html/second_section.html';
       $template = file_get_contents($template_path);
 
+      $site_url = qa_opt('site_url');
       $params = array(
         '^follow_count_label' => qa_lang_html('cud_lang/follow_count'),
-        '^follow_list_page_url' => '/user/'.$handle.'/following',
+        '^follow_list_page_url' => qa_path('user/'.$handle.'/following', null, $site_url),
         '^follow_count' => $content['counts']['follows'],
         '^follower_count_label' => qa_lang_html('cud_lang/follower_count'),
-        '^follower_list_page_url' => '/user/'.$handle.'/followers',
+        '^follower_list_page_url' => qa_path('user/'.$handle.'/followers', null, $site_url),
         '^follower_count' => $content['counts']['followers'],
         '^badge_count_label' => qa_lang_html('cud_lang/badge_count'),
-        '^badge_list_page_url' => '/user/'.$handle.'/badge',
+        '^badge_list_page_url' => qa_path('user/'.$handle.'/badge', null, $site_url),
         '^badge_count' => $content['counts']['badge'],
       );
 

--- a/cud-theme-main.php
+++ b/cud-theme-main.php
@@ -62,17 +62,10 @@ class cud_theme_main
         $blobid = $raw['account']['avatarblobid'];
         $handle = $raw['account']['handle'];
         $userid = $raw['account']['userid'];
-        $location = $raw['profile']['location'];
-        $groups = $raw['profile']['飼-育-群-数'];
-        $years = $raw['profile']['ニホンミツバチ-飼-育-歴'];
-        $hivetype = $raw['profile']['使-用-している-巣-箱'];
-        $about = $raw['profile']['about'];
+        $profile = $raw['newprofile'];
+        $about = $raw['userabout']['value'];
         $points = qa_lang_html_sub('cud_lang/points',$points);
         $ranking = qa_lang_html_sub('cud_lang/ranking',$raw['rank']);
-        $location_label = qa_lang_html('cud_lang/location');
-        $groups_label = qa_lang_html('cud_lang/number_gropus');
-        $rearing_history = qa_lang_html('cud_lang/rearing_history');
-        $using_hive = qa_lang_html('cud_lang/using_hive');
         $message_label = qa_lang_html('cud_lang/send_message');
         $message_url = qa_path_html('message/'.$handle);
 

--- a/cud-theme-main.php
+++ b/cud-theme-main.php
@@ -59,6 +59,7 @@ class cud_theme_main
         $favorite = isset($content['favorite']) ? $content['favorite'] : null;
 
         $site_url = qa_opt('site_url');
+        $account_url = qa_path('account', null, $site_url);
         $blobid = $raw['account']['avatarblobid'];
         $handle = $raw['account']['handle'];
         $userid = $raw['account']['userid'];

--- a/cud-utils.php
+++ b/cud-utils.php
@@ -48,9 +48,9 @@ class cud_utils
         $query = "";
         $query .= " ^users JOIN ^userpoints ON ^users.userid=^userpoints.userid";
         $query .= " LEFT JOIN ( SELECT userid, CASE WHEN title = 'about' THEN content ELSE '' END AS about";
-        $query .= " FROM qa_userprofile WHERE title like 'about' ) a ON qa_users.userid = a.userid";
+        $query .= " FROM ^userprofile WHERE title like 'about' ) a ON qa_users.userid = a.userid";
         $query .= " LEFT JOIN ( SELECT userid, CASE WHEN title = 'location' THEN content ELSE '' END AS location";
-        $query .= " FROM qa_userprofile WHERE title like 'location' ) l ON qa_users.userid = l.userid";
+        $query .= " FROM ^userprofile WHERE title like 'location' ) l ON qa_users.userid = l.userid";
         if ($type === 'following') {
             $query .= " WHERE ^users.userid IN ( ";
             $query .= " SELECT entityid ";

--- a/html/main_user_detail.html
+++ b/html/main_user_detail.html
@@ -26,18 +26,12 @@
         <?php echo $handle; ?>
       </div>
       <ul>
-        <li><span class="mdl-typography--font-bold"><?php echo $location_label; ?></span>:
-          <?php echo $location; ?>
-        </li>
-        <li><span class="mdl-typography--font-bold"><?php echo $groups_label; ?></span>:
-          <?php echo $groups; ?>
-        </li>
-        <li><span class="mdl-typography--font-bold"><?php echo $rearing_history; ?></span>:
-          <?php echo $years; ?>
-        </li>
-        <li><span class="mdl-typography--font-bold"><?php echo $using_hive; ?></span>:
-          <?php echo $hivetype; ?>
-        </li>
+        <?php foreach($profile as $field) : ?>
+          <li><span class="mdl-typography--font-bold">
+            <?php echo $field['label']; ?></span>:
+            <?php echo $field['value']; ?>
+          </li>
+        <?php endforeach; ?>
       </ul>
       <p class="mdl-typography--subhead mdl-color-text--primary">
         <i class="fa fa-trophy"></i>

--- a/html/main_user_detail.html
+++ b/html/main_user_detail.html
@@ -12,7 +12,7 @@
     <div class="mdl-cell mdl-cell--4-col mdl-typography mdl-typography--text-center">
       <img src="<?php echo $site_url;?>?qa=image&amp;qa_blobid=<?php echo $blobid; ?>&amp;qa_size=150" />
       <?php if($userid === qa_get_logged_in_userid()): ?>
-      <a class="mdl-button mdl-button__block mdl-js-button mdl-button--raised mdl-js-ripple-effect" href="/account">
+      <a class="mdl-button mdl-button__block mdl-js-button mdl-button--raised mdl-js-ripple-effect" href="<?php echo $account_url; ?>">
         <?php echo qa_lang_html('cud_lang/edit_profile'); ?>
       </a>
       <?php elseif($userid !== qa_get_logged_in_userid() && qa_get_logged_in_level() >= QA_USER_LEVEL_ADMIN) : ?>

--- a/pages/user-detail.php
+++ b/pages/user-detail.php
@@ -609,7 +609,7 @@
         if ($field['title'] !== 'about') {
             $tmp = array(
                 'key' => $field['title'],
-                'label' => $field['content'],
+                'label' => qa_user_userfield_label($field),
                 'value' => @$userprofile[$field['title']]
             );
             $newprofile[$field['position']] = $tmp;

--- a/pages/user-detail.php
+++ b/pages/user-detail.php
@@ -602,9 +602,27 @@
         $qa_content['raw']['profile'] = $userprofile;
     }
 
+    $tmp = array();
+    $newprofile = array();
+    $about = array();
+    foreach ($userfields as $field) {
+        if ($field['title'] !== 'about') {
+            $tmp = array(
+                'key' => $field['title'],
+                'label' => $field['content'],
+                'value' => @$userprofile[$field['title']]
+            );
+            $newprofile[$field['position']] = $tmp;
+        } else {
+            $about['label'] = $field['content'];
+            $about['value'] = @$userprofile[$field['title']];
+        }
+    }
     if (!$userediting) {
         $qa_content['raw']['account'] = $useraccount; // for plugin layers to access
         $qa_content['raw']['profile'] = $userprofile;
+        $qa_content['raw']['newprofile'] = $newprofile;
+        $qa_content['raw']['userabout'] = $about;
         $qa_content['raw']['userid'] = $useraccount['userid'];
         $qa_content['raw']['points'] = $userpoints;
         $qa_content['raw']['rank'] = $userrank;


### PR DESCRIPTION
- プロフィール画面 `user/{handle}`
  - プロフィールの表示方法変更 => ラベルは ^userfields テーブルから取得
  - ただし プロフィール(about)は特別
- URLが `/` からの相対パスになっているものを修正
- テーブルプレフィックスが固定担っているものを修正